### PR TITLE
shontzu/CFDS-1097/Total-asset-is-changing-for-few-seconds-in-background-while-doing-the-MT5-transfer

### DIFF
--- a/packages/appstore/src/components/main-title-bar/asset-summary.tsx
+++ b/packages/appstore/src/components/main-title-bar/asset-summary.tsx
@@ -7,12 +7,15 @@ import { observer, useStore } from '@deriv/stores';
 import './asset-summary.scss';
 import TotalAssetsLoader from 'Components/pre-loader/total-assets-loader';
 import { useTotalAccountBalance, useCFDAccounts, usePlatformAccounts, useExchangeRate } from '@deriv/hooks';
+import { useCashierStore } from '../../../../cashier/src/stores/useCashierStores';
 
 const AssetSummary = observer(() => {
     const { last_update } = useExchangeRate();
+    const { account_transfer, general_store } = useCashierStore();
     const { traders_hub, client, common } = useStore();
     const { selected_account_type, is_eu_user, no_CR_account, no_MF_account } = traders_hub;
     const { is_logging_in, is_switching, default_currency, is_landing_company_loaded } = client;
+    const { is_transfer_confirm } = account_transfer;
     const { current_language } = common;
     const { real: platform_real_accounts, demo: platform_demo_account } = usePlatformAccounts();
     const { real: cfd_real_accounts, demo: cfd_demo_accounts } = useCFDAccounts();
@@ -22,13 +25,20 @@ const AssetSummary = observer(() => {
     const is_real = selected_account_type === 'real';
     const real_total_balance = platform_real_balance.balance + cfd_real_balance.balance;
     const demo_total_balance = (platform_demo_account?.balance || 0) + cfd_demo_balance.balance;
+    const { is_loading } = general_store;
 
     const has_active_related_deriv_account = !((no_CR_account && !is_eu_user) || (no_MF_account && is_eu_user)); // if selected region is non-eu, check active cr accounts, if selected region is eu- check active mf accounts
     const eu_account = is_eu_user && !no_MF_account;
     const cr_account = !is_eu_user && !no_CR_account;
 
     //dont show loader if user has no respective regional account
-    if (((is_switching || is_logging_in) && (eu_account || cr_account)) || !is_landing_company_loaded || !last_update) {
+    if (
+        ((is_switching || is_logging_in) && (eu_account || cr_account)) ||
+        !is_landing_company_loaded ||
+        !last_update ||
+        is_loading ||
+        is_transfer_confirm
+    ) {
         return (
             <React.Fragment>
                 <div className='asset-summary__container content-loader'>


### PR DESCRIPTION
## Changes:
- while fund transfer is happening, show the `total asset loader`  instead of seeing total assets changing for few seconds
- [CU](https://app.clickup.com/t/20696747/CFDS-1097)

### Screenshots:

https://github.com/shontzu-deriv/deriv-app/assets/108507236/cc15e870-7570-4c17-9009-d9406ffba2ef

