### PR TITLE
shontzu/CFDS-1210/Gap-between-Next-button-and-tnc-bar-on-Mobile

### DIFF
--- a/packages/appstore/src/components/cfds-listing/cfds-listing.scss
+++ b/packages/appstore/src/components/cfds-listing/cfds-listing.scss
@@ -19,11 +19,13 @@
             overflow: auto;
         }
         width: 100%;
-        height: 100%;
         position: absolute;
         backface-visibility: hidden;
         transition: transform 0.6s ease;
         transform: rotateY(0deg);
+        @include mobile {
+            min-height: 100vh;
+        }
     }
     &__scrollable-content {
         @include desktop {
@@ -223,6 +225,7 @@
         display: flex;
         justify-content: center;
         @include mobile {
+            margin-bottom: 1rem;
             padding: 0.8rem;
         }
     }

--- a/packages/appstore/src/components/cfds-listing/cfds-listing.scss
+++ b/packages/appstore/src/components/cfds-listing/cfds-listing.scss
@@ -35,7 +35,7 @@
         background-color: var(--general-main-1);
         @include mobile {
             position: sticky;
-            bottom: 7.2rem;
+            bottom: 6.2rem;
         }
     }
     &__footer-button {

--- a/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-checkbox.tsx
+++ b/packages/cfd/src/Containers/jurisdiction-modal/jurisdiction-modal-checkbox.tsx
@@ -35,7 +35,7 @@ const JurisdictionCheckBox = ({
     };
 
     const getCheckboxLabel = () => (
-        <Text as='p' align='center' size={isMobile() ? 'xxs' : 'xs'} line_height='xs'>
+        <Text as='p' align='left' size={isMobile() ? 'xxs' : 'xs'} line_height='xs'>
             <Localize
                 i18n_default_text="I confirm and accept {{company}} 's <0>Terms and Conditions</0>"
                 values={{ company: dbvi_company_names[jurisdiction_selected_shortcode].name }}


### PR DESCRIPTION
## Changes:
- gap between checkbox and next button
- fix was checked for esmf and idcr account

### Screenshots:
<img src="https://github.com/binary-com/deriv-app/assets/108507236/fa9123b1-0d5f-48e4-8093-b600818c8129" height="450px"/> <-before | after-> <img src="https://github.com/binary-com/deriv-app/assets/108507236/cba11de5-3a1a-4e30-9a4f-dfb8ed049137" height="450px"/>


